### PR TITLE
fix: updates random-pet to use ue2 > uw2 in sub

### DIFF
--- a/03-first-aws-environment/bin/random-pet.sh
+++ b/03-first-aws-environment/bin/random-pet.sh
@@ -16,11 +16,11 @@ yq eval --inplace \
 
 # Updates our static backend config with unique names
 yq eval --inplace \
-    ".terraform.backend.s3.bucket = \"acme-uw2-tfstate-$RANDOM_PET\"" \
+    ".terraform.backend.s3.bucket = \"acme-ue2-tfstate-$RANDOM_PET\"" \
     stacks/catalog/globals.yaml
 
 yq eval --inplace \
-    ".terraform.backend.s3.dynamodb_table = \"acme-uw2-tfstate-lock-$RANDOM_PET\"" \
+    ".terraform.backend.s3.dynamodb_table = \"acme-ue2-tfstate-lock-$RANDOM_PET\"" \
     stacks/catalog/globals.yaml
 
 # Updates our dev + prod static-site component vars to ensure we're creating unique names


### PR DESCRIPTION
## what
* Updates random-pet.sh script to properly use ue2 when doing a substitution of the bucket + dynamo table names. 

## why
* This was causing issues with folks not being able to find their bucket.

## references
* See discussion in Slack: https://sweetops.slack.com/archives/CB6GHNLG0/p1619231524166000

