### PR TITLE
fix: ensure the workspace_key_prefix is set

### DIFF
--- a/03-first-aws-environment/stacks/ue2-root.yaml
+++ b/03-first-aws-environment/stacks/ue2-root.yaml
@@ -6,6 +6,9 @@ vars:
 components:
   terraform:
     tfstate-backend:
+      backend:
+        s3:
+          workspace_key_prefix: "tfstate-backend"
       vars:
         name: tfstate
         attributes: [TODO]


### PR DESCRIPTION
## what
* Without this setting, the terraform.tfstate file is written to the path "<namespace>-ue2-tfstate-<petname>/env:/terraform.tfstate". This change ensures that the "env:" is replaced with "tfstate-backend".

## why
* The is consistent with the object path conventions for other modules

## references
* n/a
