### PR TITLE
fix: removes installing AWS CLI V2 since geodesic latest includes it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,21 +4,6 @@ ARG CLI_NAME=tutorials
 
 FROM cloudposse/geodesic:$VERSION-$OS
 
-# Move AWS CLI v1 to aws1 and set up alternatives
-RUN mv /usr/local/bin/aws /usr/local/bin/aws1 && \
-    update-alternatives --install /usr/local/bin/aws aws /usr/local/bin/aws1 1
-
-# Install AWS CLI 2
-# Get version from https://github.com/aws/aws-cli/blob/v2/CHANGELOG.rst
-ARG AWS_CLI_VERSION=2.1.34
-RUN AWSTMPDIR=$(mktemp -d -t aws-inst-XXXXXXXXXX) && \
-    curl -sSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWS_CLI_VERSION}.zip" -o "$AWSTMPDIR/awscliv2.zip" && \
-    cd $AWSTMPDIR && \
-    unzip -qq awscliv2.zip && \
-    ./aws/install -i /usr/share/aws/v2 -b /usr/share/aws/v2/bin && \
-    update-alternatives --install /usr/local/bin/aws aws /usr/share/aws/v2/bin/aws 2 && \
-    rm -rf $AWSTMPDIR
-
 # Install ubuntu universe repo so we can install more helpful packages
 RUN apt-get install -y software-properties-common && \
     add-apt-repository "deb http://archive.ubuntu.com/ubuntu bionic universe" && \


### PR DESCRIPTION
## what
* Removes AWS CLI V2 installation from Dockerfile

## why
* AWS CLI V2 was added to the default Geodesic base image recently + The current Dockerfile instructions are [causing the image to fail to build](https://github.com/cloudposse/tutorials/runs/2766611112?check_suite_focus=true)

## references
* https://github.com/cloudposse/tutorials/runs/2766611112?check_suite_focus=true
* Originally added in: #7 

