### PR TITLE
Use cloudposse/template for arm support

### DIFF
--- a/03-first-aws-environment/components/terraform/tfstate-backend/versions.tf
+++ b/03-first-aws-environment/components/terraform/tfstate-backend/versions.tf
@@ -11,7 +11,7 @@ terraform {
       version = "~> 2.1"
     }
     template = {
-      source  = "hashicorp/template"
+      source  = "cloudposse/template"
       version = "~> 2.2"
     }
   }


### PR DESCRIPTION
## what
* Use cloudposse/template for arm support

## why
* The new cloudposse/template provider has a darwin arm binary for M1 laptops

## references
* https://github.com/cloudposse/terraform-provider-template
* https://registry.terraform.io/providers/cloudposse/template/latest

