### PR TITLE
Pin Atmos Version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ ARG VERSION=latest
 ARG OS=debian
 ARG CLI_NAME=tutorials
 ARG TF_1_VERSION=1.3.0
+ARG ATMOS_VERSION=1.4.20
 
 FROM cloudposse/geodesic:$VERSION-$OS
 
@@ -21,8 +22,9 @@ RUN apt-get update && apt-get install -y -u --allow-downgrades \
     update-alternatives --set terraform /usr/share/terraform/1/bin/terraform
 
 # Install Atmos
+ARG ATMOS_VERSION
 RUN apt-get install -y --allow-downgrades \
-    atmos \
+    atmos="${ATMOS_VERSION}-*" \
     vendir
 
 # Geodesic message of the Day


### PR DESCRIPTION
## what
- added atmos version pinning, using same version as infra-live

## why
- prevent updates to atmos from breaking the tutorials
- recent version of atmos requires `atmos.yaml` to exist, but this step isn't included in the tutorial

## future work
- bump the atmos version to the latest available
- update the tutorial steps for creating `atmos.yaml`

## references
- https://sweetops.slack.com/archives/C031919U8A0/p1667246507241569
