### PR TITLE
Debug Tutorial Atmos Workflows

### DIFF
--- a/02-atmos/atmos.yaml
+++ b/02-atmos/atmos.yaml
@@ -34,7 +34,7 @@ components:
 stacks:
   # Can also be set using 'ATMOS_STACKS_BASE_PATH' ENV var, or '--config-dir' and '--stacks-dir' command-line arguments
   # Supports both absolute and relative paths
-  base_path: "stacks"
+  base_path: "stacks/catalog"
   # Can also be set using 'ATMOS_STACKS_INCLUDED_PATHS' ENV var (comma-separated values string)
   included_paths:
     - "**/*"

--- a/02-atmos/atmos.yaml
+++ b/02-atmos/atmos.yaml
@@ -34,7 +34,7 @@ components:
 stacks:
   # Can also be set using 'ATMOS_STACKS_BASE_PATH' ENV var, or '--config-dir' and '--stacks-dir' command-line arguments
   # Supports both absolute and relative paths
-  base_path: "stacks/catalog"
+  base_path: "stacks"
   # Can also be set using 'ATMOS_STACKS_INCLUDED_PATHS' ENV var (comma-separated values string)
   included_paths:
     - "**/*"

--- a/02-atmos/stacks/catalog/example.yaml
+++ b/02-atmos/stacks/catalog/example.yaml
@@ -21,11 +21,3 @@ components:
         print_users_weather_enabled: true
 
   helmfile: {}
-
-workflows:
-  deploy-all:
-    description: Deploy terraform projects in order
-    steps:
-      - job: terraform deploy fetch-location
-      - job: terraform deploy fetch-weather
-      - job: terraform deploy output-results

--- a/02-atmos/stacks/workflows/example.yaml
+++ b/02-atmos/stacks/workflows/example.yaml
@@ -1,0 +1,7 @@
+workflows:
+  deploy-all:
+    description: Deploy terraform projects in order
+    steps:
+      - job: terraform deploy fetch-location
+      - job: terraform deploy fetch-weather
+      - job: terraform deploy output-results

--- a/02-atmos/stacks/workflows/example.yaml
+++ b/02-atmos/stacks/workflows/example.yaml
@@ -2,6 +2,6 @@ workflows:
   deploy-all:
     description: Deploy terraform projects in order
     steps:
-      - job: terraform deploy fetch-location
-      - job: terraform deploy fetch-weather
-      - job: terraform deploy output-results
+      - command: terraform deploy fetch-location
+      - command: terraform deploy fetch-weather
+      - command: terraform deploy output-results

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG VERSION=latest
 ARG OS=debian
 ARG CLI_NAME=tutorials
 ARG TF_1_VERSION=1.3.0
-ARG ATMOS_VERSION=1.9.1
+ARG ATMOS_VERSION=1.16.0
 
 FROM cloudposse/geodesic:$VERSION-$OS
 


### PR DESCRIPTION
## what
- Moved workflows to separate subfolder

## why
- `atmos.yaml` sets the workflows base_path to `stacks/workflows`
- Tutorials have an error with the atmos workflow command:
```
atmos workflow deploy-all -s example
```
- The correct command should be
```
atmos workflow deploy-all -s example -f example.yaml
```

## references
* https://sweetops.slack.com/archives/C031919U8A0/p1670531298738739

