### PR TITLE
remove ubuntu universe repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,21 +2,12 @@ ARG VERSION=latest
 ARG OS=debian
 ARG CLI_NAME=tutorials
 ARG TF_1_VERSION=1.3.0
-ARG ATMOS_VERSION=1.16.0
+ARG ATMOS_VERSION=1.41.0
 
 FROM cloudposse/geodesic:$VERSION-$OS
 
-# Install ubuntu universe repo so we can install more helpful packages
-RUN apt-get install -y software-properties-common && \
-    add-apt-repository "deb http://archive.ubuntu.com/ubuntu bionic universe" && \
-    gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv 3B4FE6ACC0B21F32 && \
-    gpg --export --armor 3B4FE6ACC0B21F32 | apt-key add - && \
-    apt-get update && \
-    apt-get install -y golang-petname
-
-
-ARG TF_1_VERSION
 # Install terraform.
+ARG TF_1_VERSION
 RUN apt-get update && apt-get install -y -u --allow-downgrades \
     terraform-1="${TF_1_VERSION}-*" && \
     update-alternatives --set terraform /usr/share/terraform/1/bin/terraform


### PR DESCRIPTION
## what
Removed: `RUN apt-get install -y software-properties-common && \
    add-apt-repository "deb http://archive.ubuntu.com/ubuntu bionic universe" && \
    gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv 3B4FE6ACC0B21F32 && \
    gpg --export --armor 3B4FE6ACC0B21F32 | apt-key add - && \
    apt-get update && \
    apt-get install -y golang-petname` in Dockerfile
## why
This script is redundant and causing an error (I might be wrong) 

## references
Please see the [issue](https://github.com/cloudposse/atmos/issues/412) I have submitted (it describes an error in details). I think I should have submitted the issue in this repo, sorry about that. 

