### PR TITLE
Update tutorial links

### DIFF
--- a/02-atmos/README.md
+++ b/02-atmos/README.md
@@ -1,3 +1,3 @@
 # Tutorial #2: Getting started with Atmos
 
-The code in this directory is an accompaniment to the [Getting started with Atmos](https://docs.cloudposse.com/tutorials/atmos-getting-started/) tutorial in our SweetOps documentation.
+The code in this directory is an accompaniment to the [Getting started with Atmos](https://atmos.tools/tutorials/atmos-getting-started/) tutorial in our SweetOps documentation.

--- a/03-first-aws-environment/README.md
+++ b/03-first-aws-environment/README.md
@@ -1,3 +1,3 @@
 # Tutorial #3: You first AWS Environment with Atmos
 
-The code in this directory is an accompaniment to the [Your first environment on AWS](https://docs.cloudposse.com/tutorials/first-aws-environment/) tutorial in our SweetOps documentation.
+The code in this directory is an accompaniment to the [Your first environment on AWS](https://atmos.tools/tutorials/first-aws-environment/) tutorial in our SweetOps documentation.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 
 -->
 
-The tutorial code examples for usage with [docs.cloudposse.com/tutorials](https://docs.cloudposse.com/tutorials/).
+The tutorial code examples for usage with [docs.cloudposse.com/category/tutorials](https://docs.cloudposse.com/category/tutorials/).
 
 
 ---


### PR DESCRIPTION
## what
- noticed these links out of date, update these links to reflect reality

## why
* old links leads to 404s like (https://docs.cloudposse.com/tutorials/first-aws-environment)


